### PR TITLE
Use ejson secrets when available at default path

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,12 @@ data:
   RAILS_MASTER_KEY: <%= Base64.strict_encode64(File.read("#{Dir.pwd}/config/credentials/production.key").strip) %>
 ```
 
-When running `mina production deploy`, it'll prompt for a branch and check the image tagged with current commit hash from selected branch is available on the repository. Then the `krane` executable is called to fill in the variables in the resource templates and apply them all to the cluster under the given namespace (see https://github.com/Shopify/krane#deploy-walkthrough for more details)
+When running `mina production deploy`, it'll prompt for a branch and check the image tagged with current commit hash from selected branch is available on the repository. Then the `krane` executable is called to fill in the variables in the resource templates and apply them all to the cluster under the given namespace (see https://github.com/Shopify/krane#deploy-walkthrough for more details)\
+
+### EJSON Encrypted secrets
+
+Krane supports generating Kubernetes secrets from an encrypted EJSON file: https://github.com/Shopify/krane#deploying-kubernetes-secrets-from-ejson. As per current Krane documentation "The ejson file must be included in the resources passed to --filenames it can not be read through stdin.", so
+following convention-over-configuration principles `mina-kubernetes` checks for the presence of a file named `secrets.ejson` in the stage folder and uses it if available.
 
 ### Passing options to krane
 

--- a/lib/mina/kubernetes.rb
+++ b/lib/mina/kubernetes.rb
@@ -103,6 +103,9 @@ def apply_kubernetes_resources(options)
     deploy_cmd = "#{proxy_env} krane deploy #{fetch(:namespace)} #{fetch(:kubernetes_context)} --stdin "
     deploy_cmd += options[:deployment_options] if options&.[](:deployment_options)
 
+    ejson_secrets_path = "#{filepaths}/secrets.ejson"
+    deploy_cmd += " --filenames #{ejson_secrets_path}" if File.exists?(ejson_secrets_path)
+
     command "#{render_cmd} | #{deploy_cmd}"
   end
 end


### PR DESCRIPTION
This checks for the presence of a `secrets.ejson` file in the deployment path and adds it to the deployment options. 

A default behaviour like this makes it easier to works with EJSON secrets without having to add any options as long as they follow that naming convention.