### PR TITLE
Make kubernetes:command task smarter

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ Prompts for branch unless image tag is set, then spins up a temporary pod with t
 
 #### `kubernetes:command`
 
-Prompts for branch unless image tag is set, then spins up a temporary pod with the image and run command given by task variable `command`, for instance with `set :command, "rails console"`. Environment variables can also be given by defining`env_hash`, i.e. `set :env_hash, {"RAILS_ENV" => "production", "MY_VAR" => "abcd123"}`
+Prompts for branch unless image tag is set, then spins up a temporary pod with the image and runs the command given in the task variable `command`, for instance with `set :command, "rails console"`. Environment variables can also be passed by defining`env_hash`, i.e. `set :env_hash, {"RAILS_ENV" => "production", "MY_VAR" => "abcd123"}`
+
+The pod will be named `command-username-branch`, and can be reattached/killed in case of disconnection.
 
 #### `kubernetes:delete`
 


### PR DESCRIPTION
Currently running commands always launches a new Kubernetes pod with a random label which doesn't ever get deleted if the connection is lost.

With this change the `run_command` method now uses a identifiable label containing command name, user name and branch name. This allows it to detect if a pod with that name already exists and if so it offers to reattach to its terminal session or delete it.

One caveat: because the pod label is using the branch name, one could reattach to a pod running an older version of that branch.

<img width="641" alt="Screen Shot 2020-09-25 at 12 56 42 pm" src="https://user-images.githubusercontent.com/192362/94221491-92852800-ff2e-11ea-9d44-75401429f4ec.png">

