### PR TITLE
use --dry-run=client option for applying namespace with kubectl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.7.1
+
+*Fixes*
+
+- Use `--dry-run=client` instead of deprecated `--dry-run` with kubectl to create/update namespace
+
 ## 2.7.0
 
 *Enhancements*

--- a/lib/mina/kubernetes.rb
+++ b/lib/mina/kubernetes.rb
@@ -62,7 +62,7 @@ def create_namespace_on_cluster
   run :local do
     comment "Create/update namespace on Kubernetes cluster..."
     proxy_env = "HTTPS_PROXY=#{fetch(:proxy)}" if fetch(:proxy)
-    command "kubectl create namespace #{fetch(:namespace)} --dry-run -o yaml | #{proxy_env} kubectl apply -f - --context=#{fetch(:kubernetes_context)}"
+    command "kubectl create namespace #{fetch(:namespace)} --dry-run=client -o yaml | #{proxy_env} kubectl apply -f - --context=#{fetch(:kubernetes_context)}"
   end
 end
 

--- a/lib/mina/kubernetes/version.rb
+++ b/lib/mina/kubernetes/version.rb
@@ -1,5 +1,5 @@
 module Mina
   module Kubernetes
-    VERSION = "2.7.0"
+    VERSION = "2.7.1"
   end
 end


### PR DESCRIPTION
Fixes `W1222 11:04:05.712600   41727 helpers.go:535] --dry-run is deprecated and can be replaced with --dry-run=client`, see https://kubernetes.io/docs/reference/kubectl/conventions/#generators