### PR TITLE
Use krane v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.0
+
+*Breaking change*
+
+- Depend on [Krane 3.0.0](https://github.com/Shopify/krane/blob/master/CHANGELOG.md#300)
+
 ## 2.7.1
 
 *Fixes*

--- a/lib/mina/kubernetes/version.rb
+++ b/lib/mina/kubernetes/version.rb
@@ -1,5 +1,5 @@
 module Mina
   module Kubernetes
-    VERSION = "2.7.1"
+    VERSION = "3.0.0"
   end
 end

--- a/mina-kubernetes.gemspec
+++ b/mina-kubernetes.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'mina', '~> 1.0'
   spec.add_runtime_dependency 'mina-multistage', '~> 1.0'
-  spec.add_runtime_dependency 'krane', '~> 2.1'
+  spec.add_runtime_dependency 'krane', '~> 3'
   spec.add_runtime_dependency 'tty-prompt'
   spec.add_runtime_dependency 'tty-spinner'
 end


### PR DESCRIPTION
See https://github.com/Shopify/krane/blob/master/CHANGELOG.md#300.
Flagged as a breaking change as compatibility with Kubernetes < 1.22 is not guaranteed, so bumping major version to be in line with krane.
